### PR TITLE
add 'money' type

### DIFF
--- a/src/net/efabrika/util/DBTablePrinter.java
+++ b/src/net/efabrika/util/DBTablePrinter.java
@@ -485,10 +485,12 @@ public class DBTablePrinter {
                             // after the point. THIS IS TOTALLY ARBITRARY and can be
                             // improved to be CONFIGURABLE.
                             if (!value.equals("NULL")) {
-                                Double dValue = rs.getDouble(i+1);
-                                value = String.format("%.3f", dValue);
+                                if (!(value.endsWith("€") || value.endsWith("$") || value.endsWith("£"))) {
+                                    Double dValue = rs.getDouble(i + 1);
+                                    value = String.format("%.3f", dValue);
+                                    break;
+                                }
                             }
-                            break;
 
                         case CATEGORY_STRING:
 


### PR DESCRIPTION
Hi. Today I used your class while I was working on a project, so I noticed that the type 'money', which is defined in sql, cannot be used.
It is considered as double, but then it will give error because of the money sign. So I added an if and I moved the break statement, in order to condider the 'money' type
as a string. 
Let me know what you think about this change.